### PR TITLE
Update sender.py

### DIFF
--- a/adslproxy/sender.py
+++ b/adslproxy/sender.py
@@ -72,7 +72,14 @@ class Sender():
         """
         while True:
             print('ADSL Start, Remove Proxy, Please wait')
-            self.remove_proxy()
+            try:
+                self.remove_proxy()
+            except:
+                while True:
+                    (status, output) = subprocess.getstatusoutput(ADSL_BASH)
+                    if status == 0:
+                        self.remove_proxy()
+                        break
             (status, output) = subprocess.getstatusoutput(ADSL_BASH)
             if status == 0:
                 print('ADSL Successfully')


### PR DESCRIPTION
拨号主进程中，首先需要删除redis中的代理ip，如果此时代理服务器不能访问外网，会报OSError，最终导致拨号程序中断，对 self.remove_proxy()添加异常处理，可以避免这种情况发生